### PR TITLE
Reduce configuration to setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ mac: ## Install macOS KeyBindings, setup finder customizations and keyboard pref
 	-@$(CURDIR)/mac/mac-os.sh
 
 .PHONY: all
-all: mac dotfiles brew  ## Execute `mac`, `dotfiles` and `brew` in this order
+all: mac brew dotfiles  ## Execute `mac`, `brew` and `dotfiles` in this order
 
 .PHONY: help
 help:

--- a/brew/packages.txt
+++ b/brew/packages.txt
@@ -1,10 +1,11 @@
+wget
+coreutils
 zsh
 zsh-syntax-highlighting
 fzf
 watch
 git
 vegeta
-wget
 telnet
 kubernetes-cli
 kubernetes-helm

--- a/config.sh
+++ b/config.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
+
 # Description  ENV var specifying dotfiles destination directory
 # ==============================================================
 export DOTFILES_HOME_DIR=${HOME}/.dotfiles
 
-# Description  ENV var specifying codebase root folder
-# ====================================================
-export CODEBASE=${HOME}/codebase
 
 # Description  ENV var dotfiles repository path (+alias)
 # ======================================================
-export DOTFILES_REPO=${CODEBASE}/github/dotfiles
+SCRIPT=$(greadlink -f "$0")
+
+export DOTFILES_REPO=$(dirname "$SCRIPT")
 alias dotfiles=${DOTFILES_REPO}
+
+# Description  ENV var specifying codebase root folder
+# ====================================================
+SCRIPT=$(greadlink -f "$0")
+
+export CODEBASE=$(dirname $DOTFILES_REPO)
 
 # Description  ENV var specifying environmental settings e.g. Go, JDK etc..
 # =========================================================================


### PR DESCRIPTION
automatically identify dotfiles repository location to reduce need for manual configuration.
I had to reorder the 'all' command to first install brew packages so coreutils can be used in the 'dotfiles' command.
In addition wget is required for zsh-syntax-highlighting so I reordered the package installation